### PR TITLE
Add "Edit on github" Button to pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -164,7 +164,7 @@
     editButton.href = githubEditURL;
     editButton.target = '_blank';
     editButton.rel = 'noopener noreferrer';
-    editButton.innerHTML = '<button type="button" class="btn btn-dark bg-light-subtle border-light-subtle text-secondary" style="margin-right: 5px;">Edit this page on GitHub</button>';
+    editButton.innerHTML = '<button type="button" class="btn btn-dark" style="margin-right: 5px;"><i class="bi bi-pencil-fill"></i> Edit this page</button>';
 
     // Find the parent element of the btn-group in the contentDiv
     const btnGroup = contentDiv.querySelector('.btn-group');

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,28 +125,64 @@
   <script src="/.modules/marked/marked.min.js" crossorigin="anonymous"></script>
   <script src="/.modules/highlight.js/highlight.min.js" crossorigin="anonymous"></script>
   <script>
-    var u = new URL(window.location.href);
-    var d = u.searchParams.get('page');
-    try { document.querySelector('a[href="?page='+d+'"] button').classList.add("disabled") } catch {  }
-    if(d) { a = './pages/'+d+'.md' } else { a = './pages/Documentation.md' }
-    fetch(a)
-      .then(b => {
-        if (!b.ok) {
-          throw new Error(`Network response was not ok: ${b.status}`);
-          window.location="?page=Error"
-        }
-        return b.text();
-      })
-      .then(markdownContent => {
-        document.getElementById('content').innerHTML = marked.parse(markdownContent);
-        document.querySelectorAll(".hl-escape").forEach(function(element) {
-          element.innerHTML = element.innerHTML.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
-        });
-        hljs.highlightAll(document.getElementById('content'));
-      })
-      .catch(c => {
-        console.error('Error fetching the Markdown content:', c);
+  var u = new URL(window.location.href);
+  var d = u.searchParams.get('page');
+  try { document.querySelector('a[href="?page='+d+'"] button').classList.add("disabled") } catch {  }
+  if(d) { a = './pages/'+d+'.md' } else { a = './pages/Documentation.md' }
+  fetch(a)
+    .then(b => {
+      if (!b.ok) {
+        throw new Error(`Network response was not ok: ${b.status}`);
         window.location="?page=Error"
+      }
+      return b.text();
+    })
+    .then(markdownContent => {
+      document.getElementById('content').innerHTML = marked.parse(markdownContent);
+      document.querySelectorAll(".hl-escape").forEach(function(element) {
+        element.innerHTML = element.innerHTML.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
       });
+      hljs.highlightAll(document.getElementById('content'));
+
+      // Add "Edit on GitHub" button
+      const contentDiv = document.getElementById('content');
+      if (contentDiv) {
+        addGitHubEditButton(d, contentDiv); // Call the function to add the button
+      }
+    })
+    .catch(c => {
+      console.error('Error fetching the Markdown content:', c);
+      window.location="?page=Error"
+    });
+
+    function addGitHubEditButton(page, contentDiv) {
+    // Construct the correct GitHub URL for the markdown file
+    const githubRepoURL = 'https://github.com/teamblueprint/web/edit/main/docs/pages/';
+    const githubEditURL = `${githubRepoURL}${page}.md`;
+
+    const editButton = document.createElement('a');
+    editButton.href = githubEditURL;
+    editButton.target = '_blank';
+    editButton.rel = 'noopener noreferrer';
+    editButton.innerHTML = '<button type="button" class="btn btn-dark bg-light-subtle border-light-subtle text-secondary" style="margin-right: 5px;">Edit this page on GitHub</button>';
+
+    // Find the parent element of the btn-group in the contentDiv
+    const btnGroup = contentDiv.querySelector('.btn-group');
+    if (btnGroup) {
+      editButton.style.marginRight = '10px'; // Optional: Adjust margin between the buttons
+
+      const parentElement = btnGroup.parentElement;
+      if (parentElement) {
+        parentElement.insertBefore(editButton, btnGroup); // Insert the button before the btn-group
+      } else {
+        console.error('Parent element not found.');
+      }
+    } else {
+      console.error('btn-group element not found.');
+    }
+  }
+
   </script>
+  
+
 </body>


### PR DESCRIPTION
This change will add an **"Edit this page on Github"** button to all pages, that contain the "next/previous" buttons. 

Since **blueprint.zip** is open-source i thought this would be a nice button for users to easily edit pages if there is mistakes or something that they would like that add. clicking on this button will open the edit url for that specific page, as an example, if you click this button on **"developing-extensions/Writing-extensions"** it would open this url **"https://github.com/teamblueprint/web/edit/main/docs/pages/developing-extensions/Writing-extensions.md"**.

Feel free to make any changes you may want to make or not to merge these changes. This didn't take me a lot of time anyway so it doesn't really matter what you decide to do with it.

**Preview**:
![image](https://github.com/teamblueprint/web/assets/135278375/052c8621-a985-46e8-ab9c-c54d3364e2c1)


